### PR TITLE
fix x86 prereq make target

### DIFF
--- a/Prerequisites.md
+++ b/Prerequisites.md
@@ -44,7 +44,7 @@ Test it for x86
 
 ```bash
     make clean
-    make ia32_simple_defconfig; make silentoldconfig
+    make x86_simple_defconfig; make silentoldconfig
     make
     qemu-system-i386 -nographic -m 512 -cpu Haswell -kernel images/kernel-ia32-pc99 -initrd images/capdl-loader-experimental-image-ia32-pc99
     # quit with Ctrl-A X


### PR DESCRIPTION
Prior to this commit, Prerequisites.md suggests users test their
environment for x86 with `make ia32_simple_defconfig`; however, the
target that exists in the camkes project's configs directory is
`x86_simple_defconfig` not `ia32_`. This commit updates the instructions
so that users testing their initial build environment don't run into a
problem that's a documentation project rather than an actual environment
problem.