### PR TITLE
Wrap seL4_DebugNameThread with CONFIG_DEBUG_BUILD

### DIFF
--- a/exercises/hello-2-nolibs/src/util.c
+++ b/exercises/hello-2-nolibs/src/util.c
@@ -33,7 +33,7 @@ void __arch_putchar(int c) {
 
 /* set a thread's name for debugging purposes */
 void name_thread(seL4_CPtr tcb, char *name) {
-#ifdef SEL4_DEBUG_KERNEL
+#ifdef CONFIG_DEBUG_BUILD
     seL4_DebugNameThread(tcb, name);
 #endif
 }

--- a/exercises/hello-2/src/util.c
+++ b/exercises/hello-2/src/util.c
@@ -33,7 +33,7 @@ void __arch_putchar(int c) {
 
 /* set a thread's name for debugging purposes */
 void name_thread(seL4_CPtr tcb, char *name) {
-#ifdef SEL4_DEBUG_KERNEL
+#ifdef CONFIG_DEBUG_BUILD
     seL4_DebugNameThread(tcb, name);
 #endif
 }

--- a/exercises/hello-3-nolibs/src/util.c
+++ b/exercises/hello-3-nolibs/src/util.c
@@ -33,7 +33,7 @@ void __arch_putchar(int c) {
 
 /* set a thread's name for debugging purposes */
 void name_thread(seL4_CPtr tcb, char *name) {
-#ifdef SEL4_DEBUG_KERNEL
+#ifdef CONFIG_DEBUG_BUILD
     seL4_DebugNameThread(tcb, name);
 #endif
 }

--- a/exercises/hello-3/src/util.c
+++ b/exercises/hello-3/src/util.c
@@ -33,7 +33,7 @@ void __arch_putchar(int c) {
 
 /* set a thread's name for debugging purposes */
 void name_thread(seL4_CPtr tcb, char *name) {
-#ifdef SEL4_DEBUG_KERNEL
+#ifdef CONFIG_DEBUG_BUILD
     seL4_DebugNameThread(tcb, name);
 #endif
 }

--- a/exercises/hello-4-app/src/util.c
+++ b/exercises/hello-4-app/src/util.c
@@ -33,7 +33,7 @@ void __arch_putchar(int c) {
 
 /* set a thread's name for debugging purposes */
 void name_thread(seL4_CPtr tcb, char *name) {
-#ifdef SEL4_DEBUG_KERNEL
+#ifdef CONFIG_DEBUG_BUILD
     seL4_DebugNameThread(tcb, name);
 #endif
 }

--- a/exercises/hello-4/src/util.c
+++ b/exercises/hello-4/src/util.c
@@ -33,7 +33,7 @@ void __arch_putchar(int c) {
 
 /* set a thread's name for debugging purposes */
 void name_thread(seL4_CPtr tcb, char *name) {
-#ifdef SEL4_DEBUG_KERNEL
+#ifdef CONFIG_DEBUG_BUILD
     seL4_DebugNameThread(tcb, name);
 #endif
 }

--- a/exercises/hello-timer-client/src/util.c
+++ b/exercises/hello-timer-client/src/util.c
@@ -33,7 +33,7 @@ void __arch_putchar(int c) {
 
 /* set a thread's name for debugging purposes */
 void name_thread(seL4_CPtr tcb, char *name) {
-#ifdef SEL4_DEBUG_KERNEL
+#ifdef CONFIG_DEBUG_BUILD
     seL4_DebugNameThread(tcb, name);
 #endif
 }

--- a/exercises/hello-timer/src/util.c
+++ b/exercises/hello-timer/src/util.c
@@ -33,7 +33,7 @@ void __arch_putchar(int c) {
 
 /* set a thread's name for debugging purposes */
 void name_thread(seL4_CPtr tcb, char *name) {
-#ifdef SEL4_DEBUG_KERNEL
+#ifdef CONFIG_DEBUG_BUILD
     seL4_DebugNameThread(tcb, name);
 #endif
 }

--- a/solutions/hello-2-nolibs/src/util.c
+++ b/solutions/hello-2-nolibs/src/util.c
@@ -33,7 +33,7 @@ void __arch_putchar(int c) {
 
 /* set a thread's name for debugging purposes */
 void name_thread(seL4_CPtr tcb, char *name) {
-#ifdef SEL4_DEBUG_KERNEL
+#ifdef CONFIG_DEBUG_BUILD
     seL4_DebugNameThread(tcb, name);
 #endif
 }

--- a/solutions/hello-2/src/util.c
+++ b/solutions/hello-2/src/util.c
@@ -33,7 +33,7 @@ void __arch_putchar(int c) {
 
 /* set a thread's name for debugging purposes */
 void name_thread(seL4_CPtr tcb, char *name) {
-#ifdef SEL4_DEBUG_KERNEL
+#ifdef CONFIG_DEBUG_BUILD
     seL4_DebugNameThread(tcb, name);
 #endif
 }

--- a/solutions/hello-3-nolibs/src/util.c
+++ b/solutions/hello-3-nolibs/src/util.c
@@ -33,7 +33,7 @@ void __arch_putchar(int c) {
 
 /* set a thread's name for debugging purposes */
 void name_thread(seL4_CPtr tcb, char *name) {
-#ifdef SEL4_DEBUG_KERNEL
+#ifdef CONFIG_DEBUG_BUILD
     seL4_DebugNameThread(tcb, name);
 #endif
 }

--- a/solutions/hello-3/src/util.c
+++ b/solutions/hello-3/src/util.c
@@ -33,7 +33,7 @@ void __arch_putchar(int c) {
 
 /* set a thread's name for debugging purposes */
 void name_thread(seL4_CPtr tcb, char *name) {
-#ifdef SEL4_DEBUG_KERNEL
+#ifdef CONFIG_DEBUG_BUILD
     seL4_DebugNameThread(tcb, name);
 #endif
 }

--- a/solutions/hello-4-app/src/util.c
+++ b/solutions/hello-4-app/src/util.c
@@ -33,7 +33,7 @@ void __arch_putchar(int c) {
 
 /* set a thread's name for debugging purposes */
 void name_thread(seL4_CPtr tcb, char *name) {
-#ifdef SEL4_DEBUG_KERNEL
+#ifdef CONFIG_DEBUG_BUILD
     seL4_DebugNameThread(tcb, name);
 #endif
 }

--- a/solutions/hello-4/src/util.c
+++ b/solutions/hello-4/src/util.c
@@ -33,7 +33,7 @@ void __arch_putchar(int c) {
 
 /* set a thread's name for debugging purposes */
 void name_thread(seL4_CPtr tcb, char *name) {
-#ifdef SEL4_DEBUG_KERNEL
+#ifdef CONFIG_DEBUG_BUILD
     seL4_DebugNameThread(tcb, name);
 #endif
 }

--- a/solutions/hello-timer-client/src/util.c
+++ b/solutions/hello-timer-client/src/util.c
@@ -33,7 +33,7 @@ void __arch_putchar(int c) {
 
 /* set a thread's name for debugging purposes */
 void name_thread(seL4_CPtr tcb, char *name) {
-#ifdef SEL4_DEBUG_KERNEL
+#ifdef CONFIG_DEBUG_BUILD
     seL4_DebugNameThread(tcb, name);
 #endif
 }

--- a/solutions/hello-timer/src/util.c
+++ b/solutions/hello-timer/src/util.c
@@ -33,7 +33,7 @@ void __arch_putchar(int c) {
 
 /* set a thread's name for debugging purposes */
 void name_thread(seL4_CPtr tcb, char *name) {
-#ifdef SEL4_DEBUG_KERNEL
+#ifdef CONFIG_DEBUG_BUILD
     seL4_DebugNameThread(tcb, name);
 #endif
 }


### PR DESCRIPTION
The removed SEL4_DEBUG_KERNEL is only used for the kernel, and
not in user space.
Tested by checkout out sel4-solutions manifest branch, building all configs and running them:
```
repo init -m sel4-solutions.xml && repo sync
for i in `ls configs/ia32_hello-* | sed 's/configs\///'` ; do echo "building and testing $i" && make $i && make && make simulate ; done
```