### PR TITLE
hello-camkes-1: Hide soluton for idl4 file

### DIFF
--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -165,6 +165,7 @@ endfunction()
 
 find_package(capdl REQUIRED)
 file(GLOB_RECURSE capdl_python ${PYTHON_CAPDL_PATH}/*.py)
+set(PYTHON3 "python3" CACHE INTERNAL "")
 
 set(python_with_capdl ${CMAKE_COMMAND} -E env PYTHONPATH=${PYTHON_CAPDL_PATH} ${PYTHON3})
 set(capdl_linker_tool ${python_with_capdl} ${CAPDL_LINKER_TOOL})

--- a/tutorials/hello-camkes-1/hello-camkes-1.md
+++ b/tutorials/hello-camkes-1/hello-camkes-1.md
@@ -174,7 +174,6 @@ assembly {
 **Exercise** Define the interface for hello in `interfaces/HelloSimple.idl4`. 
 
 ```c
-/*- filter File("interfaces/HelloSimple.idl4") --*/
 /* Simple RPC interface */
 procedure HelloSimple {
 /*-- filter TaskContent("hello", TaskContentType.BEFORE, subtask="interface") -*/
@@ -183,11 +182,12 @@ procedure HelloSimple {
      * hint 2: look at https://github.com/seL4/camkes-tool/blob/master/docs/index.md#creating-an-application
      */
 /*-- endfilter -*/
+/*-- filter ExcludeDocs() -*/
 /*-- filter TaskContent("hello", TaskContentType.COMPLETED, subtask="interface") -*/
     void say_hello(in string str);
 /*-- endfilter -*/
-};
 /*-- endfilter -*/
+};
 ```
 
 **Exercise** Implement the RPC hello function.
@@ -311,7 +311,17 @@ component Echo {
 }
 /*-- endfilter -*/
 ```
+```
+/*- filter File("interfaces/HelloSimple.idl4") --*/
+/* @TAG(DATA61_BSD) */
 
+/* Simple RPC interface */
+procedure HelloSimple {
+/*? include_task_type_append([("hello", 'interface')]) ?*/
+};
+
+/*-- endfilter -*/
+```
 ```
 /*- filter TaskCompletion("hello", TaskContentType.ALL) --*/
 Component echo saying: hello world


### PR DESCRIPTION
Fixes #34. Hide the solution for the idl4 definition part of the
tutorial at the start.