### PR TITLE
CMake: Find PYTHON3 binary before use

### DIFF
--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -165,6 +165,7 @@ endfunction()
 
 find_package(capdl REQUIRED)
 file(GLOB_RECURSE capdl_python ${PYTHON_CAPDL_PATH}/*.py)
+set(PYTHON3 "python3" CACHE INTERNAL "")
 
 set(python_with_capdl ${CMAKE_COMMAND} -E env PYTHONPATH=${PYTHON_CAPDL_PATH} ${PYTHON3})
 set(capdl_linker_tool ${python_with_capdl} ${CAPDL_LINKER_TOOL})


### PR DESCRIPTION
Fixes #35. Set PYTHON3 before use. This previously relied on another
part of the CMake scripts setting PYTHON3 and being processed
beforehand which isn't as stable.