### PR TITLE
Correctly calculate the number of EndpointObjets

### DIFF
--- a/tutorials/untyped/untyped.md
+++ b/tutorials/untyped/untyped.md
@@ -297,7 +297,7 @@ entire untyped object. However, this fails, because the untyped is already compl
     // TODO revoke the child untyped
 
     // allocate the whole child_untyped as endpoints
-    seL4_Word num_eps = BIT(untyped_size_bits - seL4_EndpointBits);
+    seL4_Word num_eps = BIT(untyped_size_bits / seL4_EndpointBits);
     error = seL4_Untyped_Retype(child_untyped, seL4_EndpointObject, 0, seL4_CapInitThreadCNode, 0, 0, child_tcb, num_eps);
     ZF_LOGF_IF(error != seL4_NoError, "Failed to create endpoints.");
 
@@ -309,7 +309,7 @@ entire untyped object. However, this fails, because the untyped is already compl
     assert(error == seL4_NoError);
 
      // allocate the whole child_untyped as endpoints
-    seL4_Word num_eps = BIT(untyped_size_bits - seL4_EndpointBits);
+    seL4_Word num_eps = BIT(untyped_size_bits / seL4_EndpointBits);
     error = seL4_Untyped_Retype(child_untyped, seL4_EndpointObject, 0, seL4_CapInitThreadCNode, 0, 0, child_tcb, num_eps);
     ZF_LOGF_IF(error != seL4_NoError, "Failed to create endpoints.");
 


### PR DESCRIPTION
The number of EndpointObjects to fill the entire endpoint object should be the size of the untyped object *divided* by the size of the EndpointObjects. The code previous to this PR works, but it does not fill up the object completely, creating a misleading tutorial description.

This bug in the tutorial may be a typo, since for example, `/` and `-` are the same key on a German keyboard with US layout.

I'm just proposing a change to this Markdown file and hope that the change will magically propagate to the code, or do I need to change the actual code somewhere, too?