### PR TITLE
Address cmake warnings

### DIFF
--- a/Findsel4-tutorials.cmake
+++ b/Findsel4-tutorials.cmake
@@ -58,4 +58,4 @@ macro(sel4_tutorials_setup_capdl_tutorial_environment)
 endmacro()
 
 include(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(camkes-tool DEFAULT_MSG SEL4_TUTORIALS_DIR)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(sel4-tutorials DEFAULT_MSG SEL4_TUTORIALS_DIR)

--- a/Findsel4-tutorials.cmake
+++ b/Findsel4-tutorials.cmake
@@ -11,50 +11,50 @@ mark_as_advanced(SEL4_TUTORIALS_DIR)
 include(${SEL4_TUTORIALS_DIR}/cmake/helpers.cmake)
 
 macro(sel4_tutorials_regenerate_tutorial tutorial_dir)
-    # generate tutorial sources into directory
+  # generate tutorial sources into directory
 
-    GenerateTutorial(${tutorial_dir})
-    if("${CMAKE_CURRENT_LIST_FILE}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt")
-        get_property(tute_hack GLOBAL PROPERTY DONE_TUTE_HACK)
-        if(NOT tute_hack)
-            set_property(GLOBAL PROPERTY DONE_TUTE_HACK TRUE)
-            # We are in the main project phase and regenerating the tutorial
-            # may have updated the file calling us.  So we do some magic...
-            include(${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt)
-            return()
-        endif()
+  GenerateTutorial(${tutorial_dir})
+  if("${CMAKE_CURRENT_LIST_FILE}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt")
+    get_property(tute_hack GLOBAL PROPERTY DONE_TUTE_HACK)
+    if(NOT tute_hack)
+      set_property(GLOBAL PROPERTY DONE_TUTE_HACK TRUE)
+      # We are in the main project phase and regenerating the tutorial
+      # may have updated the file calling us.  So we do some magic...
+      include(${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt)
+      return()
     endif()
+  endif()
 
 endmacro()
 
 macro(sel4_tutorials_import_libsel4tutorials)
-    add_subdirectory(${SEL4_TUTORIALS_DIR}/libsel4tutorials libsel4tutorials)
+  add_subdirectory(${SEL4_TUTORIALS_DIR}/libsel4tutorials libsel4tutorials)
 endmacro()
 
 macro(sel4_tutorials_setup_roottask_tutorial_environment)
 
-    find_package(seL4 REQUIRED)
-    find_package(elfloader-tool REQUIRED)
-    find_package(musllibc REQUIRED)
-    find_package(util_libs REQUIRED)
-    find_package(seL4_libs REQUIRED)
+  find_package(seL4 REQUIRED)
+  find_package(elfloader-tool REQUIRED)
+  find_package(musllibc REQUIRED)
+  find_package(util_libs REQUIRED)
+  find_package(seL4_libs REQUIRED)
 
-    sel4_import_kernel()
-    elfloader_import_project()
+  sel4_import_kernel()
+  elfloader_import_project()
 
-    # This sets up environment build flags and imports musllibc and runtime libraries.
-    musllibc_setup_build_environment_with_sel4runtime()
-    sel4_import_libsel4()
-    util_libs_import_libraries()
-    sel4_libs_import_libraries()
-    sel4_tutorials_import_libsel4tutorials()
+  # This sets up environment build flags and imports musllibc and runtime libraries.
+  musllibc_setup_build_environment_with_sel4runtime()
+  sel4_import_libsel4()
+  util_libs_import_libraries()
+  sel4_libs_import_libraries()
+  sel4_tutorials_import_libsel4tutorials()
 
 endmacro()
 
 macro(sel4_tutorials_setup_capdl_tutorial_environment)
-    sel4_tutorials_setup_roottask_tutorial_environment()
-    capdl_import_project()
-    CapDLToolInstall(install_capdl_tool CAPDL_TOOL_BINARY)
+  sel4_tutorials_setup_roottask_tutorial_environment()
+  capdl_import_project()
+  CapDLToolInstall(install_capdl_tool CAPDL_TOOL_BINARY)
 endmacro()
 
 include(FindPackageHandleStandardArgs)

--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -6,66 +6,55 @@
 
 # Helper that takes a filename and makes the directory where that file would go if
 function(EnsureDir filename)
-    get_filename_component(dir "${filename}" DIRECTORY)
-    file(MAKE_DIRECTORY "${dir}")
+  get_filename_component(dir "${filename}" DIRECTORY)
+  file(MAKE_DIRECTORY "${dir}")
 endfunction(EnsureDir)
 
 # Wrapper around `file(RENAME` that ensures the rename succeeds by creating the destination
 # directory if it does not exist
 function(Rename src dest)
-    EnsureDir("${dest}")
-    file(RENAME "${src}" "${dest}")
+  EnsureDir("${dest}")
+  file(RENAME "${src}" "${dest}")
 endfunction(Rename)
 
 # Wrapper around using `cmake -E copy` that tries to ensure the copy succeeds by first
 # creating the destination directory if it does not exist
 function(Copy src dest)
-    EnsureDir("${dest}")
-    execute_process(
-        COMMAND
-            ${CMAKE_COMMAND} -E copy "${src}" "${dest}"
-        RESULT_VARIABLE exit_status
-    )
-    if(NOT ("${exit_status}" EQUAL 0))
-        message(FATAL_ERROR "Failed to copy ${src} to ${dest}")
-    endif()
+  EnsureDir("${dest}")
+  execute_process(COMMAND ${CMAKE_COMMAND} -E copy "${src}" "${dest}" RESULT_VARIABLE exit_status)
+  if(NOT ("${exit_status}" EQUAL 0))
+    message(FATAL_ERROR "Failed to copy ${src} to ${dest}")
+  endif()
 endfunction(Copy)
 
 # Return non-zero if files one and two are not the same.
 function(DiffFiles res one two)
-    execute_process(
-        COMMAND
-            diff -q "${one}" "${two}"
-        RESULT_VARIABLE exit_status
-        OUTPUT_VARIABLE OUTPUT
-        ERROR_VARIABLE OUTPUT
-    )
-    set(${res} ${exit_status} PARENT_SCOPE)
+  execute_process(COMMAND diff -q "${one}" "${two}" RESULT_VARIABLE exit_status
+                  OUTPUT_VARIABLE OUTPUT ERROR_VARIABLE OUTPUT)
+  set(${res} ${exit_status} PARENT_SCOPE)
 endfunction()
 
 # Try to update output and old with the value of input
 # Only update output with input if input != old
 # Fail if input != old and output != old
 function(CopyIfUpdated input output old)
-    if(EXISTS ${output})
-        DiffFiles(template_updated ${input} ${old})
-        DiffFiles(instance_updated ${output} ${old})
-        if(template_updated AND instance_updated)
-            message(
-                FATAL_ERROR
-                    "Template has been updated and the instantiated tutorial has been updated. \
-             Changes would be lost if proceeded."
-            )
-        endif()
-        set(do_update ${template_updated})
-    else()
-        set(do_update TRUE)
+  if(EXISTS ${output})
+    DiffFiles(template_updated ${input} ${old})
+    DiffFiles(instance_updated ${output} ${old})
+    if(template_updated AND instance_updated)
+      message(
+        FATAL_ERROR "Template has been updated and the instantiated tutorial has been updated. \
+             Changes would be lost if proceeded.")
     endif()
-    if(do_update)
-        Copy(${input} ${output})
-        Copy(${input} ${old})
-    endif()
-    file(REMOVE ${input})
+    set(do_update ${template_updated})
+  else()
+    set(do_update TRUE)
+  endif()
+  if(do_update)
+    Copy(${input} ${output})
+    Copy(${input} ${old})
+  endif()
+  file(REMOVE ${input})
 
 endfunction()
 
@@ -73,24 +62,12 @@ endfunction()
 # Report a conflict if a file in source_dir and target_dir are different with respect to old_dir
 function(UpdateGeneratedFiles source_dir target_dir old_dir files)
 
-    separate_arguments(file_list NATIVE_COMMAND ${files})
-    foreach(file ${file_list})
-        string(
-            REPLACE
-                ${source_dir}
-                ${old_dir}
-                old
-                ${file}
-        )
-        string(
-            REPLACE
-                ${source_dir}
-                ${target_dir}
-                target
-                ${file}
-        )
-        CopyIfUpdated(${file} ${target} ${old})
-    endforeach()
+  separate_arguments(file_list NATIVE_COMMAND ${files})
+  foreach(file ${file_list})
+    string(REPLACE ${source_dir} ${old_dir} old ${file})
+    string(REPLACE ${source_dir} ${target_dir} target ${file})
+    CopyIfUpdated(${file} ${target} ${old})
+  endforeach()
 
 endfunction()
 
@@ -100,33 +77,25 @@ endfunction()
 # the reported input files will be added as a cmake dependency and will
 # trigger the generation if they are modified.
 function(ExecuteGenerationProcess input_dir output_dir generated_files)
-    set(input_files ${CMAKE_CURRENT_BINARY_DIR}/input_files)
-    set(output_files ${CMAKE_CURRENT_BINARY_DIR}/output_files)
+  set(input_files ${CMAKE_CURRENT_BINARY_DIR}/input_files)
+  set(output_files ${CMAKE_CURRENT_BINARY_DIR}/output_files)
 
-    include(${input_dir}/.tute_config)
+  include(${input_dir}/.tute_config)
 
-    execute_process(
-        COMMAND
-            ${CMAKE_COMMAND} -E env ${TUTE_COMMAND}
-        OUTPUT_VARIABLE OUTPUT
-        ERROR_VARIABLE OUTPUT
-        RESULT_VARIABLE res
-    )
-    if(res)
-        message(FATAL_ERROR "Failed to render: ${TUTE_COMMAND}, ${OUTPUT}")
-    endif()
-    # Set cmake to regenerate if any of the input files to the TUTE_COMMAND are updated
-    file(READ "${input_files}" files)
-    separate_arguments(file_list NATIVE_COMMAND ${files})
-    if("${CMAKE_CURRENT_LIST_FILE}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt")
-        set_property(
-            DIRECTORY "${CMAKE_SOURCE_DIR}"
-            APPEND
-            PROPERTY CMAKE_CONFIGURE_DEPENDS "${file_list}"
-        )
-    endif()
-    file(READ "${output_files}" files)
-    set(${generated_files} ${files} PARENT_SCOPE)
+  execute_process(COMMAND ${CMAKE_COMMAND} -E env ${TUTE_COMMAND} OUTPUT_VARIABLE OUTPUT
+                  ERROR_VARIABLE OUTPUT RESULT_VARIABLE res)
+  if(res)
+    message(FATAL_ERROR "Failed to render: ${TUTE_COMMAND}, ${OUTPUT}")
+  endif()
+  # Set cmake to regenerate if any of the input files to the TUTE_COMMAND are updated
+  file(READ "${input_files}" files)
+  separate_arguments(file_list NATIVE_COMMAND ${files})
+  if("${CMAKE_CURRENT_LIST_FILE}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt")
+    set_property(DIRECTORY "${CMAKE_SOURCE_DIR}" APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+                                                                 "${file_list}")
+  endif()
+  file(READ "${output_files}" files)
+  set(${generated_files} ${files} PARENT_SCOPE)
 endfunction()
 
 # Generate a tutorial in dir.
@@ -136,36 +105,33 @@ endfunction()
 # will be updated in dir, unless there is a conflict.  A conflict
 # is when the file in dir has been modified since the last generation.
 function(GenerateTutorial full_path)
-    get_filename_component(dir ${full_path} NAME)
-    get_filename_component(base_dir ${full_path} DIRECTORY)
+  get_filename_component(dir ${full_path} NAME)
+  get_filename_component(base_dir ${full_path} DIRECTORY)
 
-    # Implement include_guard() functionality within a function that
-    # can only be called once. Using include_guard() is considered dangerous
-    # within functions as it will be affected by other include_guard() calls
-    # within functions within the same file.
-    get_property(gen_tutorial GLOBAL PROPERTY GenerateTutorialONCE)
-    if(NOT gen_tutorial)
-        set_property(GLOBAL PROPERTY GenerateTutorialONCE TRUE)
-    else()
-        # If already generated the tutorial in this run we don't need to do so again.
-        return()
-    endif()
+  # Implement include_guard() functionality within a function that
+  # can only be called once. Using include_guard() is considered dangerous
+  # within functions as it will be affected by other include_guard() calls
+  # within functions within the same file.
+  get_property(gen_tutorial GLOBAL PROPERTY GenerateTutorialONCE)
+  if(NOT gen_tutorial)
+    set_property(GLOBAL PROPERTY GenerateTutorialONCE TRUE)
+  else()
+    # If already generated the tutorial in this run we don't need to do so again.
+    return()
+  endif()
 
-    if(EXISTS ${base_dir}/${dir}/.tute_config)
-        set(output_dir ${CMAKE_CURRENT_BINARY_DIR}/.tutegen/${dir}/gen)
-        set(old_output_dir ${CMAKE_CURRENT_BINARY_DIR}/.tutegen/${dir}/old)
-        set(target_dir ${base_dir}/${dir})
+  if(EXISTS ${base_dir}/${dir}/.tute_config)
+    set(output_dir ${CMAKE_CURRENT_BINARY_DIR}/.tutegen/${dir}/gen)
+    set(old_output_dir ${CMAKE_CURRENT_BINARY_DIR}/.tutegen/${dir}/old)
+    set(target_dir ${base_dir}/${dir})
 
-        ExecuteGenerationProcess(${base_dir}/${dir} ${output_dir} generated_files)
-        UpdateGeneratedFiles(${output_dir} ${target_dir} ${old_output_dir} ${generated_files})
-    endif()
-    if(NOT EXISTS ${base_dir}/${dir}/CMakeLists.txt)
-        message(
-            FATAL_ERROR
-                "Could not find: ${base_dir}/${dir}/CMakeLists.txt"
-                "It is required that ${base_dir}/${dir} contains a CMakeLists.txt"
-        )
-    endif()
+    ExecuteGenerationProcess(${base_dir}/${dir} ${output_dir} generated_files)
+    UpdateGeneratedFiles(${output_dir} ${target_dir} ${old_output_dir} ${generated_files})
+  endif()
+  if(NOT EXISTS ${base_dir}/${dir}/CMakeLists.txt)
+    message(FATAL_ERROR "Could not find: ${base_dir}/${dir}/CMakeLists.txt"
+                        "It is required that ${base_dir}/${dir} contains a CMakeLists.txt")
+  endif()
 
 endfunction()
 
@@ -177,81 +143,70 @@ set(python_with_capdl ${CMAKE_COMMAND} -E env PYTHONPATH=${PYTHON_CAPDL_PATH} ${
 set(capdl_linker_tool ${python_with_capdl} ${CAPDL_LINKER_TOOL})
 
 function(DeclareCDLRootImage cdl cdl_target)
-    cmake_parse_arguments(PARSE_ARGV 2 CDLROOTTASK "" "" "ELF;ELF_DEPENDS")
-    if(NOT "${CDLROOTTASK_UNPARSED_ARGUMENTS}" STREQUAL "")
-        message(FATAL_ERROR "Unknown arguments to DeclareCDLRootImage")
-    endif()
+  cmake_parse_arguments(PARSE_ARGV 2 CDLROOTTASK "" "" "ELF;ELF_DEPENDS")
+  if(NOT "${CDLROOTTASK_UNPARSED_ARGUMENTS}" STREQUAL "")
+    message(FATAL_ERROR "Unknown arguments to DeclareCDLRootImage")
+  endif()
 
-    CapDLToolCFileGen(
-        ${cdl_target}_cspec
-        ${cdl_target}_cspec.c
-        FALSE
-        "$<TARGET_PROPERTY:object_sizes,FILE_PATH>"
-        ${cdl}
-        "${CAPDL_TOOL_BINARY}"
-        MAX_IRQS
-        ${CapDLLoaderMaxIRQs}
-        DEPENDS
-        ${cdl_target}
-        install_capdl_tool
-        "${CAPDL_TOOL_BINARY}"
-    )
+  CapDLToolCFileGen(
+    ${cdl_target}_cspec
+    ${cdl_target}_cspec.c
+    FALSE
+    "$<TARGET_PROPERTY:object_sizes,FILE_PATH>"
+    ${cdl}
+    "${CAPDL_TOOL_BINARY}"
+    MAX_IRQS
+    ${CapDLLoaderMaxIRQs}
+    DEPENDS
+    ${cdl_target}
+    install_capdl_tool
+    "${CAPDL_TOOL_BINARY}")
 
-    # Ask the CapDL tool to generate an image with our given copied/mangled instances
-    BuildCapDLApplication(
-        C_SPEC
-        "${cdl_target}_cspec.c"
-        ELF
-        ${CDLROOTTASK_ELF}
-        DEPENDS
-        ${CDLROOTTASK_ELF_DEPENDS}
-        ${cdl_target}_cspec
-        OUTPUT
-        "capdl-loader"
-    )
-    include(rootserver)
-    DeclareRootserver("capdl-loader")
+  # Ask the CapDL tool to generate an image with our given copied/mangled instances
+  BuildCapDLApplication(
+    C_SPEC
+    "${cdl_target}_cspec.c"
+    ELF
+    ${CDLROOTTASK_ELF}
+    DEPENDS
+    ${CDLROOTTASK_ELF_DEPENDS}
+    ${cdl_target}_cspec
+    OUTPUT
+    "capdl-loader")
+  include(rootserver)
+  DeclareRootserver("capdl-loader")
 endfunction()
 
 function(cdl_ld outfile output_target)
-    cmake_parse_arguments(PARSE_ARGV 2 CDL_LD "" "" "ELF;KEYS;MANIFESTS;DEPENDS")
-    if(NOT "${CDL_LD_UNPARSED_ARGUMENTS}" STREQUAL "")
-        message(FATAL_ERROR "Unknown arguments to cdl_ld")
-    endif()
+  cmake_parse_arguments(PARSE_ARGV 2 CDL_LD "" "" "ELF;KEYS;MANIFESTS;DEPENDS")
+  if(NOT "${CDL_LD_UNPARSED_ARGUMENTS}" STREQUAL "")
+    message(FATAL_ERROR "Unknown arguments to cdl_ld")
+  endif()
 
-    add_custom_command(
-        OUTPUT "${outfile}"
-        COMMAND
-            ${capdl_linker_tool}
-            --arch=${KernelSel4Arch}
-            --object-sizes $<TARGET_PROPERTY:object_sizes,FILE_PATH> gen_cdl
-            --manifest-in ${CDL_LD_MANIFESTS}
-            --elffile ${CDL_LD_ELF}
-            --keys ${CDL_LD_KEYS}
-            --outfile ${outfile}
-        DEPENDS ${CDL_LD_ELF} ${capdl_python} ${CDL_LD_MANIFESTS}
-    )
-    add_custom_target(${output_target} DEPENDS "${outfile}")
-    add_dependencies(${output_target} ${CDL_LD_DEPENDS} object_sizes)
+  add_custom_command(
+    OUTPUT "${outfile}"
+    COMMAND
+      ${capdl_linker_tool} --arch=${KernelSel4Arch} --object-sizes
+      $<TARGET_PROPERTY:object_sizes,FILE_PATH> gen_cdl --manifest-in ${CDL_LD_MANIFESTS} --elffile
+      ${CDL_LD_ELF} --keys ${CDL_LD_KEYS} --outfile ${outfile}
+    DEPENDS ${CDL_LD_ELF} ${capdl_python} ${CDL_LD_MANIFESTS})
+  add_custom_target(${output_target} DEPENDS "${outfile}")
+  add_dependencies(${output_target} ${CDL_LD_DEPENDS} object_sizes)
 
 endfunction()
 
 function(cdl_pp manifest_in target)
-    cmake_parse_arguments(PARSE_ARGV 2 CDL_PP "" "" "ELF;CFILE;DEPENDS")
-    if(NOT "${CDL_PP_UNPARSED_ARGUMENTS}" STREQUAL "")
-        message(FATAL_ERROR "Unknown arguments to cdl_pp")
-    endif()
+  cmake_parse_arguments(PARSE_ARGV 2 CDL_PP "" "" "ELF;CFILE;DEPENDS")
+  if(NOT "${CDL_PP_UNPARSED_ARGUMENTS}" STREQUAL "")
+    message(FATAL_ERROR "Unknown arguments to cdl_pp")
+  endif()
 
-    add_custom_command(
-        OUTPUT ${CDL_PP_CFILE}
-        COMMAND
-            ${capdl_linker_tool}
-            --arch=${KernelSel4Arch}
-            --object-sizes $<TARGET_PROPERTY:object_sizes,FILE_PATH> build_cnode
-            --manifest-in=${manifest_in}
-            --elffile ${CDL_PP_ELF}
-            --ccspace ${CDL_PP_CFILE}
-        DEPENDS ${capdl_python} ${manifest_in} object_sizes
-    )
-    add_custom_target(${target} DEPENDS ${CDL_PP_CFILE})
+  add_custom_command(
+    OUTPUT ${CDL_PP_CFILE}
+    COMMAND
+      ${capdl_linker_tool} --arch=${KernelSel4Arch} --object-sizes
+      $<TARGET_PROPERTY:object_sizes,FILE_PATH> build_cnode --manifest-in=${manifest_in} --elffile
+      ${CDL_PP_ELF} --ccspace ${CDL_PP_CFILE}
+    DEPENDS ${capdl_python} ${manifest_in} object_sizes)
+  add_custom_target(${target} DEPENDS ${CDL_PP_CFILE})
 endfunction()

--- a/libsel4tutorials/CMakeLists.txt
+++ b/libsel4tutorials/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.10)
 
 add_library(sel4tutorials STATIC EXCLUDE_FROM_ALL src/constructors.c src/alloc.c)
 

--- a/libsel4tutorials/CMakeLists.txt
+++ b/libsel4tutorials/CMakeLists.txt
@@ -9,15 +9,14 @@ cmake_minimum_required(VERSION 3.10)
 add_library(sel4tutorials STATIC EXCLUDE_FROM_ALL src/constructors.c src/alloc.c)
 
 target_link_libraries(
-    sel4tutorials
-    sel4_autoconf
-    sel4runtime
-    muslc
-    sel4
-    sel4platsupport
-    sel4muslcsys
-    sel4runtime_Config
-)
+  sel4tutorials
+  sel4_autoconf
+  sel4runtime
+  muslc
+  sel4
+  sel4platsupport
+  sel4muslcsys
+  sel4runtime_Config)
 
 # We force a dependency on the constructor symbol otherwise the linker won't link in the file
 target_link_libraries(sel4tutorials -Wl,-u -Wl,register_debug_putchar)

--- a/settings.cmake
+++ b/settings.cmake
@@ -8,57 +8,48 @@ include_guard(GLOBAL)
 
 set(project_dir "${CMAKE_CURRENT_LIST_DIR}/../../")
 file(GLOB project_modules ${project_dir}/projects/*)
-list(
-    APPEND
-        CMAKE_MODULE_PATH
-        ${project_dir}/kernel
-        ${project_dir}/tools/seL4/cmake-tool/helpers/
-        ${project_dir}/tools/seL4/elfloader-tool/
-        ${project_modules}
-)
+list(APPEND CMAKE_MODULE_PATH ${project_dir}/kernel ${project_dir}/tools/seL4/cmake-tool/helpers/
+     ${project_dir}/tools/seL4/elfloader-tool/ ${project_modules})
 set(POLLY_DIR ${project_dir}/tools/polly CACHE INTERNAL "")
 
 include(application_settings)
 
 # Deal with the top level target-triplet variables.
 if(NOT TUT_BOARD)
-    message(
-        FATAL_ERROR
-            "Please select a board to compile for. Choose either pc or zynq7000\n\t`-DTUT_BOARD=<PREFERENCE>`"
-    )
+  message(
+    FATAL_ERROR
+      "Please select a board to compile for. Choose either pc or zynq7000\n\t`-DTUT_BOARD=<PREFERENCE>`"
+  )
 endif()
 
 # Set arch and board specific kernel parameters here.
 if(${TUT_BOARD} STREQUAL "pc")
-    set(KernelArch "x86" CACHE STRING "" FORCE)
-    set(KernelPlatform "pc99" CACHE STRING "" FORCE)
-    if(${TUT_ARCH} STREQUAL "ia32")
-        set(KernelSel4Arch "ia32" CACHE STRING "" FORCE)
-    elseif(${TUT_ARCH} STREQUAL "x86_64")
-        set(KernelSel4Arch "x86_64" CACHE STRING "" FORCE)
-    else()
-        message(FATAL_ERROR "Unsupported PC architecture ${TUT_ARCH}")
-    endif()
+  set(KernelArch "x86" CACHE STRING "" FORCE)
+  set(KernelPlatform "pc99" CACHE STRING "" FORCE)
+  if(${TUT_ARCH} STREQUAL "ia32")
+    set(KernelSel4Arch "ia32" CACHE STRING "" FORCE)
+  elseif(${TUT_ARCH} STREQUAL "x86_64")
+    set(KernelSel4Arch "x86_64" CACHE STRING "" FORCE)
+  else()
+    message(FATAL_ERROR "Unsupported PC architecture ${TUT_ARCH}")
+  endif()
 elseif(${TUT_BOARD} STREQUAL "zynq7000")
-    # Do a quick check and warn the user if they haven't set
-    # -DARM/-DAARCH32/-DAARCH64.
-    if(
-        (NOT ARM)
-        AND (NOT AARCH32)
-        AND ((NOT CROSS_COMPILER_PREFIX) OR ("${CROSS_COMPILER_PREFIX}" STREQUAL ""))
+  # Do a quick check and warn the user if they haven't set
+  # -DARM/-DAARCH32/-DAARCH64.
+  if((NOT ARM) AND (NOT AARCH32) AND ((NOT CROSS_COMPILER_PREFIX) OR ("${CROSS_COMPILER_PREFIX}"
+                                                                      STREQUAL "")))
+    message(
+      WARNING
+        "The target machine is an ARM machine. Unless you've defined -DCROSS_COMPILER_PREFIX, you may need to set one of:\n\t-DARM/-DAARCH32/-DAARCH64"
     )
-        message(
-            WARNING
-                "The target machine is an ARM machine. Unless you've defined -DCROSS_COMPILER_PREFIX, you may need to set one of:\n\t-DARM/-DAARCH32/-DAARCH64"
-        )
-    endif()
+  endif()
 
-    set(KernelArch "arm" CACHE STRING "" FORCE)
-    set(KernelSel4Arch "aarch32" CACHE STRING "" FORCE)
-    set(KernelPlatform "zynq7000" CACHE STRING "" FORCE)
-    ApplyData61ElfLoaderSettings(${KernelPlatform} ${KernelSel4Arch})
+  set(KernelArch "arm" CACHE STRING "" FORCE)
+  set(KernelSel4Arch "aarch32" CACHE STRING "" FORCE)
+  set(KernelPlatform "zynq7000" CACHE STRING "" FORCE)
+  ApplyData61ElfLoaderSettings(${KernelPlatform} ${KernelSel4Arch})
 else()
-    message(FATAL_ERROR "Unsupported board ${TUT_BOARD}.")
+  message(FATAL_ERROR "Unsupported board ${TUT_BOARD}.")
 endif()
 
 include(${project_dir}/kernel/configs/seL4Config.cmake)
@@ -80,16 +71,16 @@ set(KernelNumDomains 1 CACHE STRING "" FORCE)
 # and they don't initialize a platsupport driver.
 ApplyCommonReleaseVerificationSettings(FALSE FALSE)
 
-if (KernelSel4ArchAarch32)
-    # Set correct aarch32 TLS register config
-    set(KernelArmTLSReg tpidruro CACHE STRING "" FORCE)
+if(KernelSel4ArchAarch32)
+  # Set correct aarch32 TLS register config
+  set(KernelArmTLSReg tpidruro CACHE STRING "" FORCE)
 endif()
 
 # We will attempt to generate a simulation script, so try and generate a simulation
 # compatible configuration
 ApplyCommonSimulationSettings(${KernelSel4Arch})
 if(FORCE_IOMMU)
-    set(KernelIOMMU ON CACHE BOOL "" FORCE)
+  set(KernelIOMMU ON CACHE BOOL "" FORCE)
 endif()
 
 find_package(sel4-tutorials REQUIRED)

--- a/tutorials/camkes-vm-crossvm/camkes-vm-crossvm.md
+++ b/tutorials/camkes-vm-crossvm/camkes-vm-crossvm.md
@@ -462,7 +462,7 @@ each argument to the print server one at a time.
 
 ```cmake
 /*-- filter TaskContent("crossvm", TaskContentType.COMPLETED, subtask="vm-pkg-print_client-cmake", completion='buildroot login') -*/
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.10)
 
 project(print_client C)
 
@@ -544,7 +544,7 @@ world
 include(${SEL4_TUTORIALS_DIR}/settings.cmake)
 sel4_tutorials_regenerate_tutorial(${CMAKE_CURRENT_SOURCE_DIR})
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.10)
 
 project(vm-app C ASM)
 find_package(camkes-vm REQUIRED)

--- a/tutorials/camkes-vm-kernel-module/module_minimal/CMakeLists.txt
+++ b/tutorials/camkes-vm-kernel-module/module_minimal/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.10)
 
 project(module-minimal C)
 

--- a/tutorials/camkes-vm-kernel-module/module_minimal/modules/CMakeLists.txt
+++ b/tutorials/camkes-vm-kernel-module/module_minimal/modules/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 #
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.10)
 if(NOT MODULE_HELPERS_FILE)
     message(FATAL_ERROR "MODULE_HELPERS_FILE is not defined")
 endif()

--- a/tutorials/camkes-vm-kernel-module/module_minimal/settings.cmake
+++ b/tutorials/camkes-vm-kernel-module/module_minimal/settings.cmake
@@ -6,7 +6,7 @@
 
 set(supported "qemu-arm-virt")
 if(NOT "${PLATFORM}" IN_LIST supported)
-    message(FATAL_ERROR "PLATFORM: ${PLATFORM} not supported.
+  message(FATAL_ERROR "PLATFORM: ${PLATFORM} not supported.
          Supported: ${supported}")
 endif()
 

--- a/tutorials/camkes-vm-linux/camkes-vm-linux.md
+++ b/tutorials/camkes-vm-linux/camkes-vm-linux.md
@@ -167,7 +167,7 @@ look at the app's `CMakeList.txt`:
 include(${SEL4_TUTORIALS_DIR}/settings.cmake)
 sel4_tutorials_regenerate_tutorial(${CMAKE_CURRENT_SOURCE_DIR})
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.10)
 
 project(vm-app C ASM)
 include(ExternalProject)
@@ -300,7 +300,7 @@ Then create a build file for the program at `pkg/hello/CMakeLists.txt`:
 
 ```cmake
 /*-- filter TaskContent("vm-pkg-hello-cmake", TaskContentType.COMPLETED, completion='buildroot login') -*/
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.10)
 
 project(hello C)
 
@@ -422,7 +422,7 @@ clean:
 Create a `modules/CMakeLists.txt` to define the new Linux module with the following content:
 ```cmake
 /*-- filter TaskContent("vm-module-poke-cmake", TaskContentType.COMPLETED, completion='buildroot login') -*/
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.10)
 
 if(NOT MODULE_HELPERS_FILE)
     message(FATAL_ERROR "MODULE_HELPERS_FILE is not defined")
@@ -562,7 +562,7 @@ POKE!!!
 include(${SEL4_TUTORIALS_DIR}/settings.cmake)
 sel4_tutorials_regenerate_tutorial(${CMAKE_CURRENT_SOURCE_DIR})
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.10)
 
 project(vm-app C ASM)
 include(ExternalProject)

--- a/tutorials/capabilities/capabilities.md
+++ b/tutorials/capabilities/capabilities.md
@@ -443,7 +443,7 @@ to become more familiar with CSpaces.
 include(${SEL4_TUTORIALS_DIR}/settings.cmake)
 sel4_tutorials_regenerate_tutorial(${CMAKE_CURRENT_SOURCE_DIR})
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.10)
 # declare the capabilities CMake project and the languages it is written in
 project(capabilities C ASM)
 

--- a/tutorials/fault-handlers/CMakeLists.txt
+++ b/tutorials/fault-handlers/CMakeLists.txt
@@ -7,7 +7,7 @@
 include(${SEL4_TUTORIALS_DIR}/settings.cmake)
 sel4_tutorials_regenerate_tutorial(${CMAKE_CURRENT_SOURCE_DIR})
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.10)
 # declare the fault-handlers CMake project and the languages it is written in
 project(fault-handlers C ASM)
 
@@ -19,7 +19,7 @@ cdl_pp(${CMAKE_CURRENT_SOURCE_DIR}/.manifest.obj cdl_pp_target
     ELF "/*?elf?*/"
     CFILE "${CMAKE_CURRENT_BINARY_DIR}/cspace_/*?elf?*/.c"
     /*- endfor -*/
-)   
+)
 
 /*- for (elf, file) in state.stash.elfs.items() -*/
 add_executable(/*?elf?*/ EXCLUDE_FROM_ALL /*?file['filename']?*/ cspace_/*?elf?*/.c)
@@ -32,7 +32,7 @@ list(APPEND elf_targets "/*?elf?*/")
 /*- endfor -*/
 
 
-cdl_ld("${CMAKE_CURRENT_BINARY_DIR}/spec.cdl" capdl_spec 
+cdl_ld("${CMAKE_CURRENT_BINARY_DIR}/spec.cdl" capdl_spec
     MANIFESTS ${CMAKE_CURRENT_SOURCE_DIR}/.allocator.obj
     ELF ${elf_files}
     KEYS ${elf_targets}

--- a/tutorials/hello-camkes-0/hello-camkes-0.md
+++ b/tutorials/hello-camkes-0/hello-camkes-0.md
@@ -153,7 +153,7 @@ directory should contain the following `CMakeLists.txt` file:
 include(${SEL4_TUTORIALS_DIR}/settings.cmake)
 sel4_tutorials_regenerate_tutorial(${CMAKE_CURRENT_SOURCE_DIR})
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.10)
 
 project(hello-camkes-0 C ASM)
 

--- a/tutorials/hello-camkes-1/hello-camkes-1.md
+++ b/tutorials/hello-camkes-1/hello-camkes-1.md
@@ -193,7 +193,7 @@ assembly {
 
 ### Define an interface
 
-**Exercise** Define the interface for hello in `interfaces/HelloSimple.idl4`. 
+**Exercise** Define the interface for hello in `interfaces/HelloSimple.idl4`.
 
 ```c
 /* Simple RPC interface */
@@ -382,7 +382,7 @@ Component echo saying: hello world
 include(${SEL4_TUTORIALS_DIR}/settings.cmake)
 sel4_tutorials_regenerate_tutorial(${CMAKE_CURRENT_SOURCE_DIR})
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.10)
 
 project(hello-camkes-1 C ASM)
 

--- a/tutorials/hello-camkes-2/hello-camkes-2.md
+++ b/tutorials/hello-camkes-2/hello-camkes-2.md
@@ -1035,7 +1035,7 @@ FAULT HANDLER: data fault from client.client_0_control
 include(${SEL4_TUTORIALS_DIR}/settings.cmake)
 sel4_tutorials_regenerate_tutorial(${CMAKE_CURRENT_SOURCE_DIR})
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.10)
 
 project(hello-camkes-2 C ASM)
 

--- a/tutorials/hello-camkes-timer/CMakeLists.txt
+++ b/tutorials/hello-camkes-timer/CMakeLists.txt
@@ -7,7 +7,7 @@
 include(${SEL4_TUTORIALS_DIR}/settings.cmake)
 sel4_tutorials_regenerate_tutorial(${CMAKE_CURRENT_SOURCE_DIR})
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.10)
 
 project(hello-camkes-timer C ASM)
 

--- a/tutorials/hello-world/hello-world.md
+++ b/tutorials/hello-world/hello-world.md
@@ -130,7 +130,7 @@ Every application and library in an seL4 project requires a `CMakeLists.txt` fil
 include(${SEL4_TUTORIALS_DIR}/settings.cmake)
 sel4_tutorials_regenerate_tutorial(${CMAKE_CURRENT_SOURCE_DIR})
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.10)
 # declare the hello-world CMake project and the languages it is written in (just C)
 project(hello-world C ASM)
 

--- a/tutorials/interrupts/CMakeLists.txt
+++ b/tutorials/interrupts/CMakeLists.txt
@@ -6,7 +6,7 @@
 include(${SEL4_TUTORIALS_DIR}/settings.cmake)
 sel4_tutorials_regenerate_tutorial(${CMAKE_CURRENT_SOURCE_DIR})
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.10)
 project(interrupts C ASM)
 
 sel4_tutorials_setup_capdl_tutorial_environment()

--- a/tutorials/ipc/CMakeLists.txt
+++ b/tutorials/ipc/CMakeLists.txt
@@ -6,7 +6,7 @@
 include(${SEL4_TUTORIALS_DIR}/settings.cmake)
 sel4_tutorials_regenerate_tutorial(${CMAKE_CURRENT_SOURCE_DIR})
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.10)
 project(ipc C ASM)
 
 sel4_tutorials_setup_capdl_tutorial_environment()
@@ -17,7 +17,7 @@ cdl_pp(${CMAKE_CURRENT_SOURCE_DIR}/.manifest.obj cdl_pp_target
     ELF "/*?elf?*/"
     CFILE "${CMAKE_CURRENT_BINARY_DIR}/cspace_/*?elf?*/.c"
     /*- endfor -*/
-)   
+)
 
 /*- for (elf, file) in state.stash.elfs.items() -*/
 add_executable(/*?elf?*/ EXCLUDE_FROM_ALL /*?file['filename']?*/ cspace_/*?elf?*/.c)
@@ -30,7 +30,7 @@ list(APPEND elf_targets "/*?elf?*/")
 /*- endfor -*/
 
 
-cdl_ld("${CMAKE_CURRENT_BINARY_DIR}/spec.cdl" capdl_spec 
+cdl_ld("${CMAKE_CURRENT_BINARY_DIR}/spec.cdl" capdl_spec
     MANIFESTS ${CMAKE_CURRENT_SOURCE_DIR}/.allocator.obj
     ELF ${elf_files}
     KEYS ${elf_targets}

--- a/tutorials/libraries-1/CMakeLists.txt
+++ b/tutorials/libraries-1/CMakeLists.txt
@@ -7,7 +7,7 @@
 include(${SEL4_TUTORIALS_DIR}/settings.cmake)
 sel4_tutorials_regenerate_tutorial(${CMAKE_CURRENT_SOURCE_DIR})
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.10)
 # declare the libraries-1 CMake project and the languages it is written in
 project(libraries-1 C ASM)
 

--- a/tutorials/libraries-2/CMakeLists.txt
+++ b/tutorials/libraries-2/CMakeLists.txt
@@ -7,7 +7,7 @@
 include(${SEL4_TUTORIALS_DIR}/settings.cmake)
 sel4_tutorials_regenerate_tutorial(${CMAKE_CURRENT_SOURCE_DIR})
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.10)
 # declare the libraries-2 CMake project and the languages it is written in
 project(libraries-2 C ASM)
 

--- a/tutorials/libraries-3/CMakeLists.txt
+++ b/tutorials/libraries-3/CMakeLists.txt
@@ -7,7 +7,7 @@
 include(${SEL4_TUTORIALS_DIR}/settings.cmake)
 sel4_tutorials_regenerate_tutorial(${CMAKE_CURRENT_SOURCE_DIR})
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.10)
 # declare the libraries-3 CMake project and the languages it is written in
 project(libraries-3 C ASM)
 

--- a/tutorials/libraries-4/CMakeLists.txt
+++ b/tutorials/libraries-4/CMakeLists.txt
@@ -7,7 +7,7 @@
 include(${SEL4_TUTORIALS_DIR}/settings.cmake)
 sel4_tutorials_regenerate_tutorial(${CMAKE_CURRENT_SOURCE_DIR})
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.10)
 # declare the libraries-4 CMake project and the languages it is written in
 project(libraries-4 C ASM)
 

--- a/tutorials/mapping/mapping.md
+++ b/tutorials/mapping/mapping.md
@@ -306,7 +306,7 @@ int main(int argc, char *argv[]) {
 include(${SEL4_TUTORIALS_DIR}/settings.cmake)
 sel4_tutorials_regenerate_tutorial(${CMAKE_CURRENT_SOURCE_DIR})
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.10)
 project(mapping C ASM)
 
 sel4_tutorials_setup_roottask_tutorial_environment()

--- a/tutorials/mcs/CMakeLists.txt
+++ b/tutorials/mcs/CMakeLists.txt
@@ -7,7 +7,7 @@
 include(${SEL4_TUTORIALS_DIR}/settings.cmake)
 sel4_tutorials_regenerate_tutorial(${CMAKE_CURRENT_SOURCE_DIR})
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.10)
 project(mcs C ASM)
 
 set(KernelIsMCS ON CACHE STRING "" FORCE)
@@ -19,7 +19,7 @@ cdl_pp(${CMAKE_CURRENT_SOURCE_DIR}/.manifest.obj cdl_pp_target
     ELF "/*?elf?*/"
     CFILE "${CMAKE_CURRENT_BINARY_DIR}/cspace_/*?elf?*/.c"
     /*- endfor -*/
-)   
+)
 
 /*- for (elf, file) in state.stash.elfs.items() -*/
 add_executable(/*?elf?*/ EXCLUDE_FROM_ALL /*?file['filename']?*/ cspace_/*?elf?*/.c)
@@ -32,7 +32,7 @@ list(APPEND elf_targets "/*?elf?*/")
 /*- endfor -*/
 
 
-cdl_ld("${CMAKE_CURRENT_BINARY_DIR}/spec.cdl" capdl_spec 
+cdl_ld("${CMAKE_CURRENT_BINARY_DIR}/spec.cdl" capdl_spec
     MANIFESTS ${CMAKE_CURRENT_SOURCE_DIR}/.allocator.obj
     ELF ${elf_files}
     KEYS ${elf_targets}

--- a/tutorials/notifications/CMakeLists.txt
+++ b/tutorials/notifications/CMakeLists.txt
@@ -7,7 +7,7 @@
 include(${SEL4_TUTORIALS_DIR}/settings.cmake)
 sel4_tutorials_regenerate_tutorial(${CMAKE_CURRENT_SOURCE_DIR})
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.10)
 project(notifications C ASM)
 
 sel4_tutorials_setup_capdl_tutorial_environment()
@@ -18,7 +18,7 @@ cdl_pp(${CMAKE_CURRENT_SOURCE_DIR}/.manifest.obj cdl_pp_target
     ELF "/*?elf?*/"
     CFILE "${CMAKE_CURRENT_BINARY_DIR}/cspace_/*?elf?*/.c"
     /*- endfor -*/
-)   
+)
 
 /*- for (elf, file) in state.stash.elfs.items() -*/
 add_executable(/*?elf?*/ EXCLUDE_FROM_ALL /*?file['filename']?*/ cspace_/*?elf?*/.c)
@@ -31,7 +31,7 @@ list(APPEND elf_targets "/*?elf?*/")
 /*- endfor -*/
 
 
-cdl_ld("${CMAKE_CURRENT_BINARY_DIR}/spec.cdl" capdl_spec 
+cdl_ld("${CMAKE_CURRENT_BINARY_DIR}/spec.cdl" capdl_spec
     MANIFESTS ${CMAKE_CURRENT_SOURCE_DIR}/.allocator.obj
     ELF ${elf_files}
     KEYS ${elf_targets}

--- a/tutorials/threads/threads.md
+++ b/tutorials/threads/threads.md
@@ -640,7 +640,7 @@ int new_thread(void *arg1, void *arg2, void *arg3) {
 include(${SEL4_TUTORIALS_DIR}/settings.cmake)
 sel4_tutorials_regenerate_tutorial(${CMAKE_CURRENT_SOURCE_DIR})
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.10)
 project(threads C ASM)
 
 sel4_tutorials_setup_capdl_tutorial_environment()

--- a/tutorials/untyped/untyped.md
+++ b/tutorials/untyped/untyped.md
@@ -470,7 +470,7 @@ int main(int argc, char *argv[]) {
 include(${SEL4_TUTORIALS_DIR}/settings.cmake)
 sel4_tutorials_regenerate_tutorial(${CMAKE_CURRENT_SOURCE_DIR})
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.10)
 project(untyped C ASM)
 
 sel4_tutorials_setup_roottask_tutorial_environment()


### PR DESCRIPTION
Address cmake warnings so the tutorials aren't full of scary warnings on first contact:

- bump minimum cmake version to 3.10

- fix package name in FIND_PACKAGE_HANDLE_STANDARD_ARGS. The package being searched for is not cmake-tool, but sel4-tutorials (hence the warning).

This unfortunately contains some trailing whitespace stripping that should have been done ages ago, but that is included in my editor. If it's too annoying to review, I can try to remove it, but it should just be 2 or 3 lines.

There is still a warning "Ignoring extra path from command line" that I don't quite understand yet. Have left that untouched for now.