### PR TITLE
Document missing tutorial dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,32 @@ Various tutorials for using seL4, its libraries, and CAmkES.
 Follow the instructions for setting up your host environment on the [seL4
 docsite](https://docs.sel4.systems/Tutorials/setting-up.html).
 
+### Troubleshooting missing host tools
+
+If a tutorial build fails with:
+
+```text
+xmllint: command not found
+```
+
+install the XML command-line tools package:
+
+```sh
+sudo apt install libxml2-utils
+```
+
+If a tutorial build fails while generating `capDL-tool/parse-capDL` with:
+
+```text
+stack: No such file or directory
+```
+
+install Haskell Stack:
+
+```sh
+sudo apt install haskell-stack
+```
+
 ## Starting a tutorial
 
 This tutorial repository is part of a larger collection of repositories, which


### PR DESCRIPTION
This adds troubleshooting notes for two missing host tools that can appear while building the tutorials:

- `xmllint`, provided by `libxml2-utils`
- Haskell `stack`, provided by `haskell-stack`

These errors can occur while generating syscall headers and while building `capDL-tool/parse-capDL`.

I encountered these while building the `hello-world` and `ipc` tutorials and added the notes to help new users diagnose the issue more quickly.