### PR TITLE
notifications: avoid returning after success

### DIFF
--- a/tutorials/notifications/notifications.md
+++ b/tutorials/notifications/notifications.md
@@ -359,6 +359,11 @@ int main(int c, char *argv[]) {
    }
 
     printf("Success!\n");
+
+    while (1) {
+        seL4_Yield();
+    }
+
     return 0;
 }
 /*-- endfilter -*/


### PR DESCRIPTION
## Summary

The `notifications` tutorial solution can print `Success!` and then fault in `tcb_consumer` at address `0` after returning from `main`.

This change keeps the consumer alive after printing `Success!` by yielding in a loop instead of returning from `main`.

## Testing

I reproduced the issue locally with the notifications solution:

```sh
cd ~/sel4/sel4-tutorials
mkdir -p notifications_fix_test
cd notifications_fix_test
../init --tut notifications --solution
cd ../notifications_fix_test_build
ninja
./simulate
```

Before this change, the tutorial reached `Success!` and then produced a post-success fault similar to:

```text
Success!
Caught cap fault in send phase at address 0
while trying to handle:
vm fault on data at address 0 with status 0x4
in thread ... "tcb_consumer" at address 0
```

After this change, the tutorial reaches `Success!` and no longer produces the post-success `tcb_consumer` fault in my local run.

## Notes

This appears related to the existing CI issue where the notifications simulation can reach success but later fail or time out after a `tcb_consumer` fault.

Related to #100 
