### PR TITLE
remove VM appliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,6 @@ can be provided to `--plat` and `--tut` respectively.
 Most tutorials support any target platform, with the exception of hello-camkes-timer, which only
 supports the zynq7000 platform.
 
-### Virtual Machine Image
-
-You can also download a [VirtualBox virtual machine appliance](https://trustworthy.systems/Downloads/sel4_tut_v3_lubuntu_16_041-v2.ova)([md5](https://trustworthy.systems/Downloads/sel4_tut_v3_lubuntu_16_041-v2.md5)) (3GB, based on Lubuntu 16.04.1 with all the seL4 tutorial prerequisites installed).
-
-This appliance is based on [VirtualBox 5.1.2](https://www.virtualbox.org/wiki/Downloads).
-You may also need to install the appropriate VirtualBox extensions available from the same page.
-
 ## Solutions
 
 To view the solutions for a tutorial instead of performing the tutorial pass the `--solution` flag

--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ docsite](https://docs.sel4.systems/Tutorials/setting-up.html).
 ## Starting a tutorial
 
 This tutorial repository is part of a larger collection of repositories, which
-are required to run the tutorial and are coordinated in a manifest file. See
-[this guide](https://docs.sel4.systems/Tutorials/get-the-tutorials.html) on how
-to check out a consistent set.
+are required to run the tutorial and are coordinated in a manifest file. After
+the setup steps above, see [this
+guide](https://docs.sel4.systems/Tutorials/get-the-tutorials.html) on how to
+check out a consistent set.
 
 Once you have that, a tutorial is started through the use of the `init` script
 that is provided in the root directory. Using this script you can specify a


### PR DESCRIPTION
The Virtual Box appliance for the tutorials is very outdated and the preferred method for doing the tutorials is now Docker anyway, so I propose to remove it completely. It does not look like we have the resources to maintain it.

In separate commit: minor wording tweak to the README to make it less easy to read over and forget the setup steps.